### PR TITLE
add example of usage with a comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ selectionsort([6,4,9,3,1,7]);
 
 selectionsort([5, 1, 12, -5, 16, 2, 12, 14]);
 // => [-5, 1, 2, 5, 12, 12, 14, 16]
+
+selectionsort([6,4,9,3,1,7], function(a, b) { return b - a; }); 
+// => [9,7,6,4,3,1]
 ```
 
 


### PR DESCRIPTION
I first thought that `selectionsort` is missing a possibility to use your own comparator, because it wasn't described in the readme.